### PR TITLE
Expose squid_group variable, remove hardcoded wcadmin.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 squid_user: proxy
+squid_group: proxy
 squid_runtime_root: "{{ runtime_root | default('/var/run') }}/squid"
 squid_pidfile_path: "{{ squid_runtime_root }}/squid.pid"
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -4,7 +4,7 @@
     state: directory
     path: "{{ squid_runtime_root }}"
     owner: "{{ squid_user }}"
-    group: wcadmin
+    group: "{{ squid_group }}"
     mode: 0775
   tags:
     - directory-structure


### PR DESCRIPTION
Haven't used ubuntu/debian much lately but wcadmin isn't a default group. Looks like a tool to manage the java webconsole.
I'm just assuming the proxy group is the best/safest to use here, I could be wrong.